### PR TITLE
Added vars that were missing for component.json template

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,6 +6,7 @@
   "project_name": "jQuery Boilerplate",
   "project_short_description": "A jump-start for jQuery plugins development.",
   "release_date": "2013-08-14",
+  "project_license": "MIT",
   "year": "2013",
   "version": "0.1.0",
   "pluginName": "boilerPlate",

--- a/{{cookiecutter.repo_name}}/component.json
+++ b/{{cookiecutter.repo_name}}/component.json
@@ -1,7 +1,7 @@
 {
   "name": "{{ cookiecutter.repo_name }}",
   "repo": "{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}",
-  "description": "{{ cookiecutter.description }}",
+  "description": "{{ cookiecutter.project_short_description }}",
   "version": "{{ cookiecutter.version }}",
   "keywords": [],
   "dependencies": {},

--- a/{{cookiecutter.repo_name}}/component.json
+++ b/{{cookiecutter.repo_name}}/component.json
@@ -6,7 +6,7 @@
   "keywords": [],
   "dependencies": {},
   "development": {},
-  "license": "{{ cookiecutter.license }}",
+  "license": "{{ cookiecutter.project_license }}",
   "main": "dist/{{ cookiecutter.repo_name }}.js",
   "scripts": [
     "dist/{{ cookiecutter.repo_name }}.js"


### PR DESCRIPTION
This adds a license var with a default value for setting up new projects and uses `cookiecutter.project_short_description` for the description in component.json. This addresses issue #2 
